### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Intl.UnitFormat API Specification [draft]
 
+![Stage 1](https://badges.aleen42.com/src/tc39_2.svg)
+
 ### Status
 
 __Stage 1__


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.